### PR TITLE
Add lens input to filter objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ extension/out/
 .DS_Store
 node_modules/
 public/js/
+.cpcache

--- a/.joker
+++ b/.joker
@@ -1,0 +1,1 @@
+{:known-macros [hx.react/defnc]}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {binaryage/devtools {:mvn/version "0.9.10"}
         devcards {:mvn/version "0.2.5"}
         binaryage/chromex {:mvn/version "0.8.0"}
-        lilactown/hx {:local/root "../clojure/hx/"};; {:mvn/version "0.5.1"}
+        lilactown/hx {:mvn/version "0.5.2"}
         lilactown/hx-frisk {:mvn/version "0.0.2-SNAPSHOT"}
         ;; lilactown/clinch {:mvn/version "1.0.0"}
         com.andrewmcveigh/cljs-time {:mvn/version "0.5.2"}


### PR DESCRIPTION
This PR adds the ability to apply a lens to both `taps` & `inspector` tabs. The lens is applied to all tapped values and only displays the filtered value of taps containing a value after it is applied - highlighting the row with a border. This will allow for easier debugging when streaming state changes to punk2. 

![image](https://user-images.githubusercontent.com/4649439/59684635-68c84780-91a8-11e9-8789-23c34e200823.png)

![image](https://user-images.githubusercontent.com/4649439/59684865-ea1fda00-91a8-11e9-824d-3cb237f27492.png)

![image](https://user-images.githubusercontent.com/4649439/59684908-fd32aa00-91a8-11e9-9da2-482e0fb8db27.png)

I can imagine that it would be valuable to hide rows that don't match the lens as well. Let me know what you think. 